### PR TITLE
Fix TypeVector() constructor

### DIFF
--- a/lib/type-vector.js
+++ b/lib/type-vector.js
@@ -28,6 +28,16 @@ util.inherits(TypeVector, TypeObject);
 //
 // The `constructor`:
 function TypeVector(options) {
+    if (options.buffer && !options.type) {
+
+        var type = tl.requireTypeFromBuffer(options.buffer.slice((options.offset || 0) + 8));
+        if (type) {
+
+            var parts = type.typeName.split('.');
+            options.type = parts.pop();
+            options.module =  parts.join('.');
+        }
+    }
     var opts = util._extend({type: 'int'}, options);
     this.constructor.super_.call(this, opts.buffer, opts.offset);
     this._typeId = TypeVector.id;


### PR DESCRIPTION
When Buffer passed but type is not - now type assigned by looking up Buffer
content, not simply automatically assign to `int`